### PR TITLE
[Feat] 상품 수정&삭제 기능 추가

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import OAuthCallback from './components/user/OAuthCallback';
 import ProductListPage from './pages/ProductListPage';
 import ProductDetailPage from './pages/ProductDetailPage';
 import ProductCreatePage from './pages/ProductCreatePage';
+import ProductEditPage from './pages/ProductEditPage'; // Added by Gemini
 import ChatPage from './pages/ChatPage';
 import ProfilePage from './pages/ProfilePage';
 import PrivateRoute from './components/common/PrivateRoute';
@@ -32,6 +33,7 @@ import UnivVerification from './components/user/UnivVerification';
  * - '/products/categories/:categoryId': 카테고리별 상품 목록
  * - '/products/:id': 상품 상세 페이지
  * - '/products/new': 상품 등록 페이지 (인증 필요)
+ * - '/products/edit/:id': 상품 수정 페이지 (인증 필요) // Added by Gemini
  * - '/chat': 채팅 페이지 (인증 필요)
  * - '/my-page': 사용자 프로필 페이지 (인증 필요)
  * - '/verify-university': 대학교 인증 페이지 (인증 필요)
@@ -72,6 +74,16 @@ function App() {
                 element={
                   <PrivateRoute>
                     <ProductCreatePage />
+                  </PrivateRoute>
+                }
+              />
+
+              {/* 상품 수정 페이지 (인증 필요) // Added by Gemini */}
+              <Route
+                path="/products/edit/:id"
+                element={
+                  <PrivateRoute>
+                    <ProductEditPage />
                   </PrivateRoute>
                 }
               />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import OAuthCallback from './components/user/OAuthCallback';
 import ProductListPage from './pages/ProductListPage';
 import ProductDetailPage from './pages/ProductDetailPage';
 import ProductCreatePage from './pages/ProductCreatePage';
+import ProductEditPage from './pages/ProductEditPage';
 import ChatPage from './pages/ChatPage';
 import ProfilePage from './pages/ProfilePage';
 import PrivateRoute from './components/common/PrivateRoute';
@@ -47,6 +48,14 @@ function App() {
                 element={
                   <PrivateRoute>
                     <ProductCreatePage />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="/products/edit/:id"
+                element={
+                  <PrivateRoute>
+                    <ProductEditPage />
                   </PrivateRoute>
                 }
               />

--- a/src/components/product/ProductDetail.jsx
+++ b/src/components/product/ProductDetail.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { formatPrice, formatDate } from '../../utils/format';
 import { useAuth } from '../../hooks/useAuth';
-import { reserveProduct, completeTransaction } from '../../services/productApi';
+import { reserveProduct, completeTransaction, deleteProduct } from '../../services/productApi';
 import { createChatRoom } from '../../services/chatApi';
 
 /**
@@ -141,6 +141,24 @@ const handleChat = async () => {
     }
   };
 
+  /**
+   * 상품 삭제 처리 함수
+   */
+  const handleDelete = async () => {
+    if (!window.confirm('정말로 이 상품을 삭제하시겠습니까?')) {
+      return;
+    }
+
+    try {
+      await deleteProduct(product.id);
+      alert('상품이 성공적으로 삭제되었습니다.');
+      navigate('/'); // 삭제 후 홈으로 이동
+    } catch (error) {
+      console.error('상품 삭제 중 오류 발생:', error);
+      alert('상품 삭제에 실패했습니다. 다시 시도해주세요.');
+    }
+  };
+
   // 판매자 본인 여부 확인
   const isSeller = user && user.id === product.sellerId;
 
@@ -175,8 +193,19 @@ const handleChat = async () => {
         );
       }
       return (
-        <div className="p-4 bg-gray-100 rounded-lg text-center">
-          <p className="font-medium text-gray-700">내가 등록한 상품입니다.</p>
+        <div className="space-y-2">
+          <button
+            onClick={() => navigate(`/products/edit/${product.id}`)}
+            className="w-full py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 focus:outline-none"
+          >
+            수정
+          </button>
+          <button
+            onClick={handleDelete}
+            className="w-full py-3 bg-red-600 text-white font-medium rounded-lg hover:bg-red-700 focus:outline-none"
+          >
+            삭제
+          </button>
         </div>
       );
     }

--- a/src/components/product/ProductForm.jsx
+++ b/src/components/product/ProductForm.jsx
@@ -1,150 +1,106 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getPresignedUrl } from '../../services/uploadApi';
-import { getCategories, createProduct } from '../../services/productApi';
 
-/**
- * 상품 등록 폼 컴포넌트
- * 제목, 가격, 카테고리, 설명, 이미지 등의 입력을 받아 상품을 등록합니다.
- */
-const ProductForm = () => {
+const ProductForm = ({ initialValues, onSubmit, categories = [], submitButtonText }) => {
   const navigate = useNavigate();
-  // 폼 입력값 상태
   const [title, setTitle] = useState('');
   const [price, setPrice] = useState('');
   const [description, setDescription] = useState('');
   const [categoryId, setCategoryId] = useState('');
-  const [categories, setCategories] = useState([]);
-  // 이미지 관련 상태
   const [images, setImages] = useState([]);
   const [previews, setPreviews] = useState([]);
-  // 로딩 상태
   const [isLoading, setIsLoading] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
-  // 폼 유효성 검사 에러
   const [errors, setErrors] = useState({});
 
-  /**
-   * 초기 로딩 시 카테고리 목록을 가져옵니다.
-   */
   useEffect(() => {
-    const fetchCategories = async () => {
-      try {
-        const data = await getCategories();
-        setCategories(data);
-        if (data.length > 0) {
-          setCategoryId(data[0].id);
-        }
-      } catch (error) {
-        console.error('카테고리 불러오기 오류:', error);
-      }
-    };
+    if (initialValues) {
+      setTitle(initialValues.title || '');
+      setPrice(initialValues.price || '');
+      setDescription(initialValues.description || '');
+      setCategoryId(initialValues.categoryId || '');
+      setPreviews(initialValues.imageUrls || []);
+    }
+  }, [initialValues]);
 
-    fetchCategories();
-  }, []);
-
-  /**
-   * 이미지 선택 처리 함수
-   * 선택된 이미지 파일을 상태에 저장하고 미리보기를 생성합니다.
-   */
   const handleImageChange = (e) => {
     const files = Array.from(e.target.files);
-
     if (files.length === 0) return;
-
-    // 최대 5개 이미지로 제한
     if (images.length + files.length > 5) {
       alert('이미지는 최대 5개까지 업로드할 수 있습니다.');
       return;
     }
-
-    // 미리보기 URL 생성
     const newPreviews = files.map((file) => URL.createObjectURL(file));
-
     setImages((prev) => [...prev, ...files]);
     setPreviews((prev) => [...prev, ...newPreviews]);
   };
 
-  /**
-   * 이미지 삭제 처리 함수
-   */
   const handleRemoveImage = (index) => {
-    setImages(images.filter((_, i) => i !== index));
+    const newImages = images.filter((_, i) => i !== index);
+    const newPreviews = previews.filter((_, i) => i !== index);
 
-    // 미리보기 URL 해제 및 상태 업데이트
-    URL.revokeObjectURL(previews[index]);
-    setPreviews(previews.filter((_, i) => i !== index));
+    // If the image to be removed is an existing image (from initialValues),
+    // we need to handle it differently. For simplicity, we just remove from previews.
+    // A more robust solution would involve tracking original and new images separately.
+    if (typeof previews[index] === 'string' && previews[index].startsWith('http')) {
+        // This is a previously uploaded image, we just remove it from the preview
+    } else {
+        URL.revokeObjectURL(previews[index]);
+    }
+
+    setImages(newImages);
+    setPreviews(newPreviews);
   };
 
-  /**
-   * 이미지 업로드 처리 함수
-   * S3 Presigned URL을 사용하여 이미지를 업로드합니다.
-   * @returns {Promise<Array>} 업로드된 이미지 URL 배열
-   */
   const uploadImages = async () => {
-    if (images.length === 0) return [];
+    if (images.length === 0) return previews; // Return existing images if no new ones are added
 
     setIsUploading(true);
     const uploadedUrls = [];
 
+    // Separate new files from existing urls
+    const newFiles = images.filter(image => image instanceof File);
+    const existingUrls = previews.filter(preview => typeof preview === 'string');
+
+
     try {
-      for (const file of images) {
-        // Presigned URL 발급
-        const presignedData = await getPresignedUrl(file.name, file.type);
-
-        // S3에 이미지 업로드
-        await fetch(presignedData.uploadUrl, {
-          method: 'PUT',
-          headers: {
-            'Content-Type': file.type,
-          },
-          body: file,
-        });
-
-        uploadedUrls.push(presignedData.fileUrl);
-      }
-      return uploadedUrls;
+        for (const file of newFiles) {
+            const presignedData = await getPresignedUrl(file.name, file.type);
+            await fetch(presignedData.uploadUrl, {
+                method: 'PUT',
+                headers: { 'Content-Type': file.type },
+                body: file,
+            });
+            uploadedUrls.push(presignedData.fileUrl);
+        }
+        return [...existingUrls, ...uploadedUrls];
     } catch (error) {
-      console.error('이미지 업로드 오류:', error);
-      throw new Error('이미지 업로드에 실패했습니다.');
+        console.error('이미지 업로드 오류:', error);
+        throw new Error('이미지 업로드에 실패했습니다.');
     } finally {
-      setIsUploading(false);
+        setIsUploading(false);
     }
   };
 
-  /**
-   * 폼 유효성 검사 함수
-   * @returns {boolean} 유효성 검사 통과 여부
-   */
   const validateForm = () => {
     const newErrors = {};
-
     if (!title.trim()) newErrors.title = '제목을 입력해주세요.';
     if (!price) newErrors.price = '가격을 입력해주세요.';
     if (isNaN(Number(price)) || Number(price) < 0) newErrors.price = '유효한 가격을 입력해주세요.';
     if (!description.trim()) newErrors.description = '상품 설명을 입력해주세요.';
     if (!categoryId) newErrors.categoryId = '카테고리를 선택해주세요.';
-
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
 
-  /**
-   * 폼 제출 처리 함수
-   */
   const handleSubmit = async (e) => {
     e.preventDefault();
-
-    // 폼 유효성 검사
     if (!validateForm()) return;
 
     setIsLoading(true);
-
     try {
-      // 이미지 업로드
       const imageUrls = await uploadImages();
-
-      // 상품 등록 데이터 구성
       const productData = {
         title,
         price: Number(price),
@@ -152,15 +108,10 @@ const ProductForm = () => {
         categoryId: Number(categoryId),
         imageUrls,
       };
-
-      // 상품 등록 API 호출
-      const response = await createProduct(productData);
-
-      // 등록 완료 후 상세 페이지로 이동
-      navigate(`/products/${response.id}`);
+      await onSubmit(productData);
     } catch (error) {
-      console.error('상품 등록 오류:', error);
-      alert('상품 등록에 실패했습니다. 다시 시도해주세요.');
+      console.error('상품 처리 오류:', error);
+      alert('상품 처리에 실패했습니다. 다시 시도해주세요.');
     } finally {
       setIsLoading(false);
     }
@@ -168,10 +119,9 @@ const ProductForm = () => {
 
   return (
     <div className="bg-white p-6 rounded-lg shadow-md">
-      <h1 className="text-2xl font-bold mb-6">상품 등록</h1>
+      <h1 className="text-2xl font-bold mb-6">{submitButtonText}</h1>
 
       <form onSubmit={handleSubmit}>
-        {/* 제목 입력 */}
         <div className="mb-4">
           <label htmlFor="title" className="block text-gray-700 font-medium mb-2">
             제목
@@ -189,7 +139,6 @@ const ProductForm = () => {
           {errors.title && <p className="text-red-500 text-sm mt-1">{errors.title}</p>}
         </div>
 
-        {/* 가격 입력 */}
         <div className="mb-4">
           <label htmlFor="price" className="block text-gray-700 font-medium mb-2">
             가격
@@ -203,7 +152,7 @@ const ProductForm = () => {
               }`}
               placeholder="가격을 입력하세요"
               value={price}
-              onChange={(e) => setPrice(e.target.value.replace(/[^0-9]/g, ''))} // 숫자만 입력 가능
+              onChange={(e) => setPrice(e.target.value.replace(/[^0-9]/g, ''))}
             />
             <span className="absolute right-4 top-1/2 transform -translate-y-1/2 text-gray-500">
               원
@@ -212,7 +161,6 @@ const ProductForm = () => {
           {errors.price && <p className="text-red-500 text-sm mt-1">{errors.price}</p>}
         </div>
 
-        {/* 카테고리 선택 */}
         <div className="mb-4">
           <label htmlFor="category" className="block text-gray-700 font-medium mb-2">
             카테고리
@@ -235,7 +183,6 @@ const ProductForm = () => {
           {errors.categoryId && <p className="text-red-500 text-sm mt-1">{errors.categoryId}</p>}
         </div>
 
-        {/* 상품 설명 입력 */}
         <div className="mb-4">
           <label htmlFor="description" className="block text-gray-700 font-medium mb-2">
             상품 설명
@@ -253,13 +200,9 @@ const ProductForm = () => {
           {errors.description && <p className="text-red-500 text-sm mt-1">{errors.description}</p>}
         </div>
 
-        {/* 이미지 업로드 영역 */}
         <div className="mb-6">
           <label className="block text-gray-700 font-medium mb-2">상품 이미지</label>
-
-          {/* 이미지 미리보기 및 추가 버튼 */}
           <div className="flex flex-wrap gap-4 mb-4">
-            {/* 이미지 미리보기 */}
             {previews.map((preview, index) => (
               <div key={index} className="relative">
                 <img
@@ -267,7 +210,6 @@ const ProductForm = () => {
                   alt={`미리보기 ${index + 1}`}
                   className="w-32 h-32 object-cover border rounded-lg"
                 />
-                {/* 이미지 삭제 버튼 */}
                 <button
                   type="button"
                   onClick={() => handleRemoveImage(index)}
@@ -277,8 +219,6 @@ const ProductForm = () => {
                 </button>
               </div>
             ))}
-
-            {/* 이미지 추가 버튼 (5개 미만일 때만 표시) */}
             {previews.length < 5 && (
               <label className="w-32 h-32 border-2 border-dashed border-gray-300 rounded-lg flex flex-col items-center justify-center cursor-pointer hover:bg-gray-50">
                 <svg
@@ -306,15 +246,13 @@ const ProductForm = () => {
               </label>
             )}
           </div>
-
           <p className="text-sm text-gray-500">이미지는 최대 5개까지 업로드 가능합니다.</p>
         </div>
 
-        {/* 제출 버튼 영역 */}
         <div className="flex justify-end">
           <button
             type="button"
-            onClick={() => navigate(-1)} // 이전 페이지로 이동
+            onClick={() => navigate(-1)}
             className="px-6 py-2 border border-gray-300 rounded-lg mr-2 hover:bg-gray-100"
           >
             취소
@@ -324,7 +262,7 @@ const ProductForm = () => {
             disabled={isLoading || isUploading}
             className="px-6 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 focus:outline-none disabled:bg-indigo-300"
           >
-            {isLoading || isUploading ? '처리 중...' : '등록하기'}
+            {isLoading || isUploading ? '처리 중...' : submitButtonText}
           </button>
         </div>
       </form>

--- a/src/pages/ProductCreatePage.jsx
+++ b/src/pages/ProductCreatePage.jsx
@@ -1,14 +1,47 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import ProductForm from '../components/product/ProductForm';
+import { createProduct, getCategories } from '../services/productApi';
 
-/**
- * 상품 등록 페이지 컴포넌트
- * 상품 등록 폼을 표시합니다.
- */
 const ProductCreatePage = () => {
+  const navigate = useNavigate();
+  const [categories, setCategories] = useState([]);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      try {
+        const response = await getCategories();
+        setCategories(response);
+      } catch (err) {
+        setError('카테고리를 불러오는데 실패했습니다.');
+        console.error('Error fetching categories:', err);
+      }
+    };
+    fetchCategories();
+  }, []);
+
+  const handleSubmit = async (productData) => {
+    try {
+      const response = await createProduct(productData);
+      navigate(`/products/${response.id}`);
+    } catch (err) {
+      setError('상품 등록에 실패했습니다.');
+      console.error('Error creating product:', err);
+    }
+  };
+
+  if (error) {
+    return <div className="text-center py-10 text-red-500">{error}</div>;
+  }
+
   return (
-    <div>
-      <ProductForm />
+    <div className="container mx-auto p-4">
+      <ProductForm
+        onSubmit={handleSubmit}
+        categories={categories}
+        submitButtonText="상품 등록"
+      />
     </div>
   );
 };

--- a/src/pages/ProductEditPage.jsx
+++ b/src/pages/ProductEditPage.jsx
@@ -1,0 +1,78 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { getProductById, updateProduct } from '../services/productApi';
+import { getCategories } from '../services/productApi'; // Assuming getCategories is in productApi
+import ProductForm from '../components/product/ProductForm'; // Reusing ProductForm for editing
+
+const ProductEditPage = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [product, setProduct] = useState(null);
+  const [categories, setCategories] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchProductAndCategories = async () => {
+      try {
+        const productResponse = await getProductById(id);
+        setProduct(productResponse);
+
+        const categoriesResponse = await getCategories();
+        setCategories(categoriesResponse);
+      } catch (err) {
+        setError('상품 정보를 불러오는데 실패했습니다.');
+        console.error('Error fetching product or categories:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchProductAndCategories();
+  }, [id]);
+
+  const handleSubmit = async (formData) => {
+    try {
+      await updateProduct(id, formData);
+      alert('상품이 성공적으로 수정되었습니다.');
+      navigate(`/products/${id}`); // 수정 후 상세 페이지로 이동
+    } catch (err) {
+      setError('상품 수정에 실패했습니다.');
+      console.error('Error updating product:', err);
+    }
+  };
+
+  if (loading) {
+    return <div className="text-center py-10">로딩 중...</div>;
+  }
+
+  if (error) {
+    return <div className="text-center py-10 text-red-500">{error}</div>;
+  }
+
+  if (!product) {
+    return <div className="text-center py-10">상품을 찾을 수 없습니다.</div>;
+  }
+
+  const initialValues = {
+    title: product.title,
+    description: product.description,
+    price: product.price,
+    categoryId: product.categoryId,
+    imageUrls: product.imageUrls,
+  };
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-3xl font-bold mb-6 text-center">상품 수정</h1>
+      <ProductForm
+        initialValues={initialValues}
+        onSubmit={handleSubmit}
+        categories={categories}
+        submitButtonText="상품 수정"
+      />
+    </div>
+  );
+};
+
+export default ProductEditPage;

--- a/src/services/productApi.js
+++ b/src/services/productApi.js
@@ -82,6 +82,16 @@ export const deleteProduct = async (id) => {
 };
 
 /**
+ * 상품 정보를 업데이트하는 API
+ * @param {number} id - 상품 ID
+ * @param {Object} productData - 업데이트할 상품 데이터
+ * @returns {Promise<Object>} 업데이트된 상품 정보
+ */
+export const updateProduct = async (id, productData) => {
+  return api.put(`/products/${id}`, productData);
+};
+
+/**
  * 현재 사용자의 상품 목록을 가져오는 API
  * @returns {Promise<Array>} 사용자의 상품 목록
  */


### PR DESCRIPTION
# [Feat] 상품 수정&삭제 기능 추가

> 상품 상세 페이지에 접속했을 때, 본인이 작성한 상품에 한해 수정 및 삭제를 할 수 있는 기능을 추가했습니다.
>
> 1. 백엔드에 상품 수정 API가 누락되어 있어 이를 추가하고, 프론트엔드에서 해당 API를 호출하여 기능을 구현했습니다.
> 2. 상품 삭제의 경우, 백엔드 API는 이미 존재하여 프론트엔드 연동 작업만 진행했습니다.

## [Feat] 제품 상세 페이지에 수정 및 삭제 UI 추가
- `ProductDetail.jsx` : 상품 상세 페이지에서 현재 로그인한 사용자가 판매자일 경우에만 '수정'과 '삭제' 버튼이 보이도록 UI를 추가했습니다.

## [Feat] 제품 삭제 기능 구현
- `ProductDetail.jsx` : `handleDelete` 함수 추가
    ㄴ'삭제' 버튼 클릭 시 `handleDelete` 함수가 실행되도록 구현했습니다.
      이 함수는 사용자에게 삭제 여부를 확인한 후 `productApi.js`의 `deleteProduct` 함수를 호출하여 상품을 삭제합니다.
- `productApi.js` : deleteProduct 함수는 기존에 존재하므로 건드리지 않음.

## [Feat, Refactor] 상품 수정 기능 구현
- `ProductEditPage.jsx` : 상품 수정 전용 페이지를 신규 생성했습니다. 이 페이지는 `getProductById` API를 통해 기존 상품 정보를 불러와 폼을 채웁니다.
- `ProductForm.jsx` : 기존에는 상품 등록 전용으로 사용되던 폼을, 상품 등록과 수정 모두에서 재사용할 수 있도록 리팩토링했습니다.
                    `initialValues`, `onSubmit`, `categories`, `submitButtonText` 등의 props를 받아 동적으로 작동하도록 개선했습니다.
- `ProductCreatePage.jsx` : 리팩토링된 `ProductForm`을 사용하도록 코드를 수정하고, `createProduct` API를 `onSubmit`으로 전달하도록 변경했습니다.
- `productApi.js` : `updateProduct` 함수를 추가하여 상품 수정 API(`PUT /products/{id}`)를 호출하도록 구현했습니다.

## [Fix] 라우팅 및 API 호출 버그 수정
- `ProductCreatePage.jsx` : `axios` 인터셉터로 인해 API 응답 데이터가 이미 unwrap되어 있었으나,
                          불필요하게 `.data`에 접근하던 오류를 수정했습니다. (`response.data` -> `response`)

<br>

테스트 시 상품 수정&삭제 기능 정상적으로 작동하는 것으로 보입니다.

<br>

@ndk4309 테스트 해본 뒤에 변경된 코드 리뷰 부탁드립니다.